### PR TITLE
Fix overflowing logo on First Access page

### DIFF
--- a/autonta/files/www/resources/default.css
+++ b/autonta/files/www/resources/default.css
@@ -52,6 +52,15 @@ div.logo {
     right: 10px;
     z-index: 2;
     height: 53px;
+    max-width: 18%;
+}
+
+div.logo img {
+    display: inline-block;
+    max-width: 100%;
+    padding-left: 10px;
+    height: auto;
+    width: auto;
 }
 
 .main_header {


### PR DESCRIPTION
This concerns the first-use page after starting with a clean valibox image. On some devices such as mobile phones, the Valibox logo overflows. This patch contains the logo to the right 18% of the screen.