### PR TITLE
sidn-unbound: add conflict with unbound

### DIFF
--- a/sidn-unbound/Makefile
+++ b/sidn-unbound/Makefile
@@ -41,6 +41,7 @@ define Package/sidn-unbound
   CATEGORY:=SIDN
   TITLE:=Unbound DNS resolver with Valibox-specific patches
   DEPENDS+= +sidn-libunbound
+  CONFLICTS:=unbound
 endef
 
 define Package/sidn-unbound/description
@@ -54,6 +55,7 @@ define Package/sidn-unbound-anchor
   CATEGORY:=SIDN
   TITLE:=DNSSEC key anchor utility
   DEPENDS+= +libexpat +sidn-unbound
+  CONFLICTS:=unbound-anchor
 endef
 
 define Package/sidn-unbound-anchor/description
@@ -80,6 +82,7 @@ define Package/sidn-unbound-control-setup
   CATEGORY:=SIDN
   TITLE:=Unbound-control setup utility
   DEPENDS+= +sidn-unbound-control +openssl-util
+  CONFLICTS:=unbound-control-setup
 endef
 
 define Package/sidn-unbound-control-setup/description
@@ -93,6 +96,7 @@ define Package/sidn-unbound-host
   CATEGORY:=SIDN
   TITLE:=Unbound-host DNS lookup utility
   DEPENDS+= +sidn-libunbound
+  CONFLICTS:=unbound-host
 endef
 
 define Package/sidn-unbound-host/description


### PR DESCRIPTION
Fixes:
```
Packages 'unbound' and 'sidn-unbound' do not conflict while providing same file: /usr/sbin/unbound
Packages 'unbound' and 'sidn-unbound' do not conflict while providing same file: /usr/sbin/unbound-checkconf
Packages 'unbound' and 'sidn-unbound' do not conflict while providing same file: /etc/unbound/named.cache
Packages 'unbound' and 'sidn-unbound' do not conflict while providing same file: /etc/init.d/unbound
```